### PR TITLE
Fix the Rust install dir and simplify the angelcam-connector Makefile

### DIFF
--- a/angelcam-connector/Makefile
+++ b/angelcam-connector/Makefile
@@ -1,27 +1,29 @@
 include $(TOPDIR)/rules.mk
 
-PKG_NAME := angelcam-connector
-PKG_LICENSE := Apache-2.0
-PKG_VERSION := 0.10.1
-PKG_RELEASE := 1
+PKG_NAME:=angelcam-connector
+PKG_VERSION:=0.10.1
+PKG_RELEASE:=1
 
-PKG_BUILD_DEPENDS := rust-lang/host
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/angelcam/arrow-client/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=31d6be013efa4bbdfb59254f2d65469cdf10a4710955d5beab133d7a3e90d07d
+PKG_BUILD_DIR:=$(BUILD_DIR)/arrow-client-$(PKG_VERSION)
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/angelcam/arrow-client.git
-PKG_SOURCE_VERSION:=v$(PKG_VERSION)
-PKG_MIRROR_HASH:=8651cb53d51642cac468948a0d40d2b04cec28e9ff046df254641b5a46cc8d87
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Angelcam Developers <dev@angelcam.com>
+
+PKG_BUILD_DEPENDS:=rust-lang/host
 
 include $(INCLUDE_DIR)/package.mk
 include ../rust-lang/files/rust-env.mk
 
 define Package/angelcam-connector
-  TITLE := Angelcam Connector
-  CATEGORY := Network
-  SECTION := net
-  DEPENDS := +libpcap +libopenssl
-  URL := https://github.com/angelcam/arrow-client
-  MAINTAINER := dev@angelcam.com
+  TITLE:=Angelcam Connector
+  CATEGORY:=Network
+  SECTION:=net
+  DEPENDS:=+libpcap +libopenssl
+  URL:=https://github.com/angelcam/arrow-client
 endef
 
 define Package/angelcam-connector/description
@@ -65,19 +67,22 @@ endef
 
 define Package/angelcam-connector/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_DIR) $(1)/etc/angelcam-connector
-	$(INSTALL_DIR) $(1)/usr/local/angelcam-connector
-	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/target/$(RUST_TARGET)/release/arrow-client \
-		$(1)/usr/bin/angelcam-connector
-	$(INSTALL_BIN) ./files/init-script $(1)/etc/init.d/angelcam-connector
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/ca.pem $(1)/usr/local/angelcam-connector/
+	$(1)/usr/bin/angelcam-connector
+
+	$(INSTALL_DIR) $(1)/etc/angelcam-connector
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rtsp-paths $(1)/etc/angelcam-connector/
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/mjpeg-paths $(1)/etc/angelcam-connector/
 	touch $(1)/etc/angelcam-connector/config.json
 	touch $(1)/etc/angelcam-connector/config-skel.json
 	chmod 600 $(1)/etc/angelcam-connector/config.json
 	chmod 600 $(1)/etc/angelcam-connector/config-skel.json
+
+	$(INSTALL_DIR) $(1)/usr/local/angelcam-connector
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/ca.pem $(1)/usr/local/angelcam-connector/
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/init-script $(1)/etc/init.d/angelcam-connector
 endef
 
 $(eval $(call BuildPackage,angelcam-connector))

--- a/angelcam-connector/Makefile
+++ b/angelcam-connector/Makefile
@@ -13,12 +13,7 @@ PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 PKG_MIRROR_HASH:=8651cb53d51642cac468948a0d40d2b04cec28e9ff046df254641b5a46cc8d87
 
 include $(INCLUDE_DIR)/package.mk
-
-ifeq ($(CONFIG_TARGET_PROFILE),"DEVICE_cznic_turris-omnia")
-  RUST_TARGET := armv7-unknown-linux-musleabihf
-else
-  RUST_TARGET := $(shell echo $(CONFIG_ARCH)-unknown-linux-$(CONFIG_TARGET_SUFFIX))
-endif
+include $(TOPDIR)/feeds/angelcampackages/rust-lang/files/rust-env.mk
 
 define Package/angelcam-connector
   TITLE := Angelcam Connector
@@ -31,22 +26,9 @@ define Package/angelcam-connector/description
   Angelcam Connector
 endef
 
-define CARGO_CONFIG
-[target.$(RUST_TARGET)]
-ar = "$(TARGET_AR)"
-linker = "$(TARGET_CC)"
-rustflags = [
-  "-C", "link-args=$(TARGET_LDFLAGS)",
-  "-C", "target-feature=-crt-static",
-]
-endef
-
-export CARGO_CONFIG
-
 define Build/Prepare
 	$(call Build/Prepare/Default)
-	mkdir $(PKG_BUILD_DIR)/.cargo
-	echo "$$$$CARGO_CONFIG" > $(PKG_BUILD_DIR)/.cargo/config
+	$(call Build/Prepare/Rust)
 endef
 
 define Build/Compile
@@ -54,9 +36,7 @@ define Build/Compile
 		cd $(PKG_BUILD_DIR) && \
 		export OPENSSL_LIB_DIR=$(STAGING_DIR)/usr/lib && \
 		export OPENSSL_INCLUDE_DIR=$(STAGING_DIR)/usr/include && \
-		export CC_$(subst -,_,$(RUST_TARGET))=$(TARGET_CC) && \
-		export CFLAGS_$(subst -,_,$(RUST_TARGET))="$(TARGET_CFLAGS)" && \
-		cargo +1.60.0 build \
+		cargo build \
 			--features "discovery threads" \
 			--release \
 			--target $(RUST_TARGET) \

--- a/angelcam-connector/Makefile
+++ b/angelcam-connector/Makefile
@@ -13,17 +13,25 @@ PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 PKG_MIRROR_HASH:=8651cb53d51642cac468948a0d40d2b04cec28e9ff046df254641b5a46cc8d87
 
 include $(INCLUDE_DIR)/package.mk
-include $(TOPDIR)/feeds/angelcampackages/rust-lang/files/rust-env.mk
+include ../rust-lang/files/rust-env.mk
 
 define Package/angelcam-connector
   TITLE := Angelcam Connector
   CATEGORY := Network
   SECTION := net
   DEPENDS := +libpcap +libopenssl
+  URL := https://github.com/angelcam/arrow-client
+  MAINTAINER := dev@angelcam.com
 endef
 
 define Package/angelcam-connector/description
-  Angelcam Connector
+  Angelcam Connector is a simple service that allows you to connect your IP
+  cameras to Angelcam Cloud easily even if you are behind a NAT. There is no
+  need for port-forwarding or a public IP address.
+
+  The application opens a secure connection to Angelcam Cloud and it works as
+  a proxy for your IP cameras. It periodically scans your local network in
+  order to keep track of your IP cameras.
 endef
 
 define Build/Prepare

--- a/reforis-angelcam-connector-plugin/Makefile
+++ b/reforis-angelcam-connector-plugin/Makefile
@@ -1,9 +1,10 @@
 include $(TOPDIR)/rules.mk
 
-PKG_NAME := reforis-angelcam-connector-plugin
-PKG_LICENSE := Apache-2.0
-PKG_VERSION := 0.1.0
-PKG_RELEASE := 1
+PKG_NAME:=reforis-angelcam-connector-plugin
+PKG_VERSION:=0.1.0
+PKG_RELEASE:=1
+
+PKG_LICENSE:=Apache-2.0
 
 PKG_BUILD_DEPENDS:=\
 	node/host \
@@ -15,21 +16,21 @@ include $(TOPDIR)/feeds/turrispackages/web/reforis/reforis/files/reforis-plugin.
 include $(TOPDIR)/feeds/turrispackages/web/reforis/reforis/files/reforis-translations.mk
 
 define Package/reforis-angelcam-connector-plugin
-  SECTION := web
-  CATEGORY := Web
-  SUBMENU := reForis
-  TITLE := reForis Angelcam Connector plugin
-  DEPENDS := \
+  SECTION:=web
+  CATEGORY:=Web
+  SUBMENU:=reForis
+  TITLE:=reForis Angelcam Connector plugin
+  DEPENDS:= \
     +reforis \
     +angelcam-connector
-  VARIANT := python3
+  VARIANT:=python3
 endef
 
 define Package/reforis-angelcam-connector-plugin/description
   reForis Angelcam Connector plugin
 endef
 
-REFORIS_TRANSLATIONS := en
+REFORIS_TRANSLATIONS:=en
 
 define Build/Prepare
 	mkdir -p $(PKG_BUILD_DIR)

--- a/rust-lang/Makefile
+++ b/rust-lang/Makefile
@@ -1,24 +1,37 @@
 include $(TOPDIR)/rules.mk
 
-PKG_NAME := rust-lang
-PKG_LICENSE := Apache-2.0/MIT
-PKG_VERSION := 1.60.0
-PKG_RELEASE := 1
+PKG_NAME:=rust-lang
+PKG_VERSION:=1.25.1
+PKG_RELEASE:=1
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/rust-lang/rustup.git
-PKG_SOURCE_VERSION:=1.24.3
-PKG_MIRROR_HASH:=ba8ebb610aaf76127a475ae899dee44e57e81341965f37b3c534196c933fc2df
+PKG_SOURCE:=rustup-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/rust-lang/rustup/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=4d062c77b08309bd212f22dd7da1957c1882509c478e57762f34ec4fb2884c9a
+HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/rustup-$(PKG_VERSION)
 
-include $(INCLUDE_DIR)/host-build.mk
+PKG_LICENSE:=Apache-2.0 MIT
+PKG_LICENSE_FILES:=LICENSE-MIT LICENSE-APACHE
+
+PKG_HOST_ONLY:=1
+HOST_BUILD_PARALLEL:=1
+
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
 include ./files/rust-env.mk
 
 Build/Compile:=:
 
+define Package/rust-lang
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Rust programming language
+  URL:=https://www.rust-lang.org/
+  BUILDONLY:=1
+endef
+
 define Host/Compile
 	sh $(HOST_BUILD_DIR)/rustup-init.sh -y \
-		--default-toolchain $(PKG_VERSION) \
+		--default-toolchain 1.60.0 \
 		--target $(RUST_TARGET) \
 		--profile minimal \
 		--no-modify-path
@@ -38,5 +51,5 @@ define Host/Clean
 	-rm -rf $(RUSTUP_HOME) $(CARGO_HOME)
 endef
 
+$(eval $(call BuildPackage,rust-lang))
 $(eval $(call HostBuild))
-$(eval $(call Build/DefaultTargets))

--- a/rust-lang/Makefile
+++ b/rust-lang/Makefile
@@ -10,8 +10,6 @@ PKG_SOURCE_URL:=https://github.com/rust-lang/rustup.git
 PKG_SOURCE_VERSION:=1.24.3
 PKG_MIRROR_HASH:=ba8ebb610aaf76127a475ae899dee44e57e81341965f37b3c534196c933fc2df
 
-HOST_BUILD_DIR := $(BUILD_DIR_HOST)/$(PKG_NAME)-$(PKG_VERSION)
-
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 include ./files/rust-env.mk

--- a/rust-lang/Makefile
+++ b/rust-lang/Makefile
@@ -12,34 +12,32 @@ PKG_MIRROR_HASH:=ba8ebb610aaf76127a475ae899dee44e57e81341965f37b3c534196c933fc2d
 
 HOST_BUILD_DIR := $(BUILD_DIR_HOST)/$(PKG_NAME)-$(PKG_VERSION)
 
-ADDITIONAL_TARGETS :=
-
-ifeq ($(CONFIG_TARGET_PROFILE),"DEVICE_cznic_turris-omnia")
-  ADDITIONAL_TARGETS += armv7-unknown-linux-musleabihf
-else
-  ADDITIONAL_TARGETS += $(shell echo $(CONFIG_ARCH)-unknown-linux-$(CONFIG_TARGET_SUFFIX))
-endif
-
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
+include ./files/rust-env.mk
 
 Build/Compile:=:
 
-define Host/Prepare
-	$(call Host/Prepare/Default)
-	chmod 755 $(HOST_BUILD_DIR)/rustup-init.sh
-endef
-
 define Host/Compile
-	test -e $$$$HOME/.cargo/bin/rustup || $(HOST_BUILD_DIR)/rustup-init.sh -y --profile minimal
-	$$$$HOME/.cargo/bin/rustup toolchain install $(PKG_VERSION)
-	$$$$HOME/.cargo/bin/rustup target add --toolchain $(PKG_VERSION) $(ADDITIONAL_TARGETS)
+	sh $(HOST_BUILD_DIR)/rustup-init.sh -y \
+		--default-toolchain $(PKG_VERSION) \
+		--target $(RUST_TARGET) \
+		--profile minimal \
+		--no-modify-path
 endef
 
 define Host/Install
-	test -e $(STAGING_DIR_HOST)/bin/cargo || ln -s $$$$HOME/.cargo/bin/cargo $(STAGING_DIR_HOST)/bin/
-	test -e $(STAGING_DIR_HOST)/bin/rustc || ln -s $$$$HOME/.cargo/bin/rustc $(STAGING_DIR_HOST)/bin/
-	test -e $(STAGING_DIR_HOST)/bin/rustup || ln -s $$$$HOME/.cargo/bin/rustup $(STAGING_DIR_HOST)/bin/
+	ln -s $(CARGO_BIN)/cargo $(STAGING_DIR_HOST)/bin/
+	ln -s $(CARGO_BIN)/rustc $(STAGING_DIR_HOST)/bin/
+	ln -s $(CARGO_BIN)/rustup $(STAGING_DIR_HOST)/bin/
+endef
+
+define Host/Clean
+	$(call Host/Clean/Default)
+	-rm $(STAGING_DIR_HOST)/bin/cargo
+	-rm $(STAGING_DIR_HOST)/bin/rustc
+	-rm $(STAGING_DIR_HOST)/bin/rustup
+	-rm -rf $(RUSTUP_HOME) $(CARGO_HOME)
 endef
 
 $(eval $(call HostBuild))

--- a/rust-lang/files/rust-env.mk
+++ b/rust-lang/files/rust-env.mk
@@ -4,9 +4,17 @@ export CARGO_HOME:=$(STAGING_DIR_HOST)/lib/cargo
 CARGO_BIN:=$(CARGO_HOME)/bin
 
 # NOTE: The Rust target triplet does not always match the target triplet used
-# by OpenWrt. You can add exceptions for your target profile here:
-ifeq ($(CONFIG_TARGET_PROFILE),"DEVICE_cznic_turris-omnia")
+# by OpenWrt. You can add exceptions for your device here.
+
+# Turris MOX
+ifneq ($(findstring aarch64,$(CONFIG_ARCH)),)
+  RUST_TARGET := aarch64-unknown-linux-musl
+# Turris Omnia
+else ifneq ($(findstring arm,$(CONFIG_ARCH)),)
   RUST_TARGET := armv7-unknown-linux-musleabihf
+# Turris 1.x
+else ifneq ($(findstring powerpc,$(CONFIG_ARCH)),)
+  RUST_TARGET := powerpc_unknown_linux_muslspe
 else
   RUST_TARGET := $(shell echo $(CONFIG_ARCH)-unknown-linux-$(CONFIG_TARGET_SUFFIX))
 endif

--- a/rust-lang/files/rust-env.mk
+++ b/rust-lang/files/rust-env.mk
@@ -1,0 +1,32 @@
+export RUSTUP_HOME:=$(STAGING_DIR_HOST)/lib/rustup
+export CARGO_HOME:=$(STAGING_DIR_HOST)/lib/cargo
+
+CARGO_BIN:=$(CARGO_HOME)/bin
+
+# NOTE: The Rust target triplet does not always match the target triplet used
+# by OpenWrt. You can add exceptions for your target profile here:
+ifeq ($(CONFIG_TARGET_PROFILE),"DEVICE_cznic_turris-omnia")
+  RUST_TARGET := armv7-unknown-linux-musleabihf
+else
+  RUST_TARGET := $(shell echo $(CONFIG_ARCH)-unknown-linux-$(CONFIG_TARGET_SUFFIX))
+endif
+
+define CARGO_CONFIG
+[target.$(RUST_TARGET)]
+ar = "$(TARGET_AR)"
+linker = "$(TARGET_CC)"
+rustflags = [
+  "-C", "link-args=$(TARGET_LDFLAGS)",
+  "-C", "target-feature=-crt-static",
+]
+endef
+
+export CARGO_CONFIG
+
+define Build/Prepare/Rust
+	mkdir $(PKG_BUILD_DIR)/.cargo
+	echo "$$$$CARGO_CONFIG" > $(PKG_BUILD_DIR)/.cargo/config
+endef
+
+export CC_$(subst -,_,$(RUST_TARGET)):=$(TARGET_CC)
+export CFLAGS_$(subst -,_,$(RUST_TARGET)):=$(TARGET_CFLAGS)


### PR DESCRIPTION
Rust will be installed within the build tree (the default location used to be user's home). As a side-result of this change, some variables common for rust-lang and angelcam-connector have been moved to `rust-lang/files/rust-env.mk`. This file contains also common initialization for Rust builds that can further simplify Makefiles for Rust apps.