### PR TITLE
Split the rust-lang package into rustup and rust-lang

### DIFF
--- a/rust-lang/Makefile
+++ b/rust-lang/Makefile
@@ -1,13 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rust-lang
-PKG_VERSION:=1.25.1
+PKG_VERSION:=1.63.0
 PKG_RELEASE:=1
-
-PKG_SOURCE:=rustup-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/rust-lang/rustup/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=4d062c77b08309bd212f22dd7da1957c1882509c478e57762f34ec4fb2884c9a
-HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/rustup-$(PKG_VERSION)
 
 PKG_LICENSE:=Apache-2.0 MIT
 PKG_LICENSE_FILES:=LICENSE-MIT LICENSE-APACHE
@@ -15,11 +10,11 @@ PKG_LICENSE_FILES:=LICENSE-MIT LICENSE-APACHE
 PKG_HOST_ONLY:=1
 HOST_BUILD_PARALLEL:=1
 
+HOST_BUILD_DEPENDS:=rustup/host
+
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
 include ./files/rust-env.mk
-
-Build/Compile:=:
 
 define Package/rust-lang
   SECTION:=lang
@@ -29,26 +24,19 @@ define Package/rust-lang
   BUILDONLY:=1
 endef
 
-define Host/Compile
-	sh $(HOST_BUILD_DIR)/rustup-init.sh -y \
-		--default-toolchain 1.60.0 \
-		--target $(RUST_TARGET) \
-		--profile minimal \
-		--no-modify-path
-endef
+Build/Compile:=:
+Host/Compile:=:
 
 define Host/Install
-	ln -s $(CARGO_BIN)/cargo $(STAGING_DIR_HOST)/bin/
-	ln -s $(CARGO_BIN)/rustc $(STAGING_DIR_HOST)/bin/
-	ln -s $(CARGO_BIN)/rustup $(STAGING_DIR_HOST)/bin/
+	rustup toolchain install \
+		--target $(RUST_TARGET) \
+		--profile minimal \
+		$(PKG_VERSION)
 endef
 
 define Host/Clean
 	$(call Host/Clean/Default)
-	-rm $(STAGING_DIR_HOST)/bin/cargo
-	-rm $(STAGING_DIR_HOST)/bin/rustc
-	-rm $(STAGING_DIR_HOST)/bin/rustup
-	-rm -rf $(RUSTUP_HOME) $(CARGO_HOME)
+	rustup toolchain uninstall $(PKG_VERSION)
 endef
 
 $(eval $(call BuildPackage,rust-lang))

--- a/rust-lang/files/rust-env.mk
+++ b/rust-lang/files/rust-env.mk
@@ -1,7 +1,4 @@
-export RUSTUP_HOME:=$(STAGING_DIR_HOST)/lib/rustup
-export CARGO_HOME:=$(STAGING_DIR_HOST)/lib/cargo
-
-CARGO_BIN:=$(CARGO_HOME)/bin
+include ../rustup/files/rustup-env.mk
 
 # NOTE: The Rust target triplet does not always match the target triplet used
 # by OpenWrt. You can add exceptions for your device here.

--- a/rustup/Makefile
+++ b/rustup/Makefile
@@ -1,0 +1,53 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=rustup
+PKG_VERSION:=1.25.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=rustup-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/rust-lang/rustup/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=4d062c77b08309bd212f22dd7da1957c1882509c478e57762f34ec4fb2884c9a
+HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/rustup-$(PKG_VERSION)
+
+PKG_LICENSE:=Apache-2.0 MIT
+PKG_LICENSE_FILES:=LICENSE-MIT LICENSE-APACHE
+
+PKG_HOST_ONLY:=1
+HOST_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
+include ./files/rustup-env.mk
+
+Build/Compile:=:
+
+define Package/rustup
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=rustup - The Rust toolchain installer
+  URL:=https://rustup.rs/
+  BUILDONLY:=1
+endef
+
+define Host/Compile
+	sh $(HOST_BUILD_DIR)/rustup-init.sh -y \
+		--default-toolchain none \
+		--no-modify-path
+endef
+
+define Host/Install
+	ln -s $(CARGO_BIN)/rustup $(STAGING_DIR_HOST)/bin/
+	ln -s $(CARGO_BIN)/cargo $(STAGING_DIR_HOST)/bin/
+	ln -s $(CARGO_BIN)/rustc $(STAGING_DIR_HOST)/bin/
+endef
+
+define Host/Clean
+	$(call Host/Clean/Default)
+	-rm $(STAGING_DIR_HOST)/bin/rustup
+	-rm $(STAGING_DIR_HOST)/bin/cargo
+	-rm $(STAGING_DIR_HOST)/bin/rustc
+	-rm -rf $(RUSTUP_HOME) $(CARGO_HOME)
+endef
+
+$(eval $(call BuildPackage,rustup))
+$(eval $(call HostBuild))

--- a/rustup/files/rustup-env.mk
+++ b/rustup/files/rustup-env.mk
@@ -1,0 +1,4 @@
+export RUSTUP_HOME:=$(STAGING_DIR_HOST)/lib/rustup
+export CARGO_HOME:=$(STAGING_DIR_HOST)/lib/cargo
+
+CARGO_BIN:=$(CARGO_HOME)/bin


### PR DESCRIPTION
As discussed in #6, this will make the package versioning clearer.