### PR TITLE
Build Rust from source instead of using Rustup

### DIFF
--- a/rust-lang/Makefile
+++ b/rust-lang/Makefile
@@ -1,19 +1,23 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rust-lang
-PKG_VERSION:=1.25.1
+PKG_VERSION:=1.63.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=rustup-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/rust-lang/rustup/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=4d062c77b08309bd212f22dd7da1957c1882509c478e57762f34ec4fb2884c9a
-HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/rustup-$(PKG_VERSION)
+PKG_SOURCE:=rustc-$(PKG_VERSION)-src.tar.gz
+PKG_SOURCE_URL:=https://static.rust-lang.org/dist/
+PKG_HASH:=1f9580295642ef5da7e475a8da2397d65153d3f2cb92849dbd08ed0effca99d0
+HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/rustc-$(PKG_VERSION)-src
 
 PKG_LICENSE:=Apache-2.0 MIT
 PKG_LICENSE_FILES:=LICENSE-MIT LICENSE-APACHE
 
 PKG_HOST_ONLY:=1
 HOST_BUILD_PARALLEL:=1
+
+HOST_BUILD_DEPENDS:=\
+	ninja/host \
+	python3/host
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
@@ -29,26 +33,53 @@ define Package/rust-lang
   BUILDONLY:=1
 endef
 
+define BUILD_CONFIG_TOML
+changelog-seen = 2
+
+[llvm]
+targets = "AArch64;ARM;Mips;PowerPC;RISCV;WebAssembly;X86"
+
+[rust]
+channel = "stable"
+
+[build]
+target = [
+	"$(subst pc,unknown,$(GNU_HOST_NAME))",
+	"$(RUST_TARGET)",
+]
+docs = false
+extended = true
+tools = ["cargo", "src"]
+
+[target.$(RUST_TARGET)]
+musl-root = "$(TOOLCHAIN_DIR)"
+
+[install]
+prefix = "$(STAGING_DIR_HOST)"
+sysconfdir = "etc"
+endef
+
+export BUILD_CONFIG_TOML
+
+define Host/Configure
+	echo "$$$$BUILD_CONFIG_TOML" > $(HOST_BUILD_DIR)/config.toml
+endef
+
 define Host/Compile
-	sh $(HOST_BUILD_DIR)/rustup-init.sh -y \
-		--default-toolchain 1.60.0 \
-		--target $(RUST_TARGET) \
-		--profile minimal \
-		--no-modify-path
+	cd $(HOST_BUILD_DIR) && ./x.py build
 endef
 
 define Host/Install
-	ln -s $(CARGO_BIN)/cargo $(STAGING_DIR_HOST)/bin/
-	ln -s $(CARGO_BIN)/rustc $(STAGING_DIR_HOST)/bin/
-	ln -s $(CARGO_BIN)/rustup $(STAGING_DIR_HOST)/bin/
+	cd $(HOST_BUILD_DIR) && ./x.py install
 endef
 
 define Host/Clean
+	(\
+		if [ -f $(STAGING_DIR_HOST)/lib/rustlib/uninstall.sh ]; then \
+			$(STAGING_DIR_HOST)/lib/rustlib/uninstall.sh; \
+		fi \
+	)
 	$(call Host/Clean/Default)
-	-rm $(STAGING_DIR_HOST)/bin/cargo
-	-rm $(STAGING_DIR_HOST)/bin/rustc
-	-rm $(STAGING_DIR_HOST)/bin/rustup
-	-rm -rf $(RUSTUP_HOME) $(CARGO_HOME)
 endef
 
 $(eval $(call BuildPackage,rust-lang))

--- a/rust-lang/files/rust-env.mk
+++ b/rust-lang/files/rust-env.mk
@@ -1,10 +1,7 @@
-export RUSTUP_HOME:=$(STAGING_DIR_HOST)/lib/rustup
-export CARGO_HOME:=$(STAGING_DIR_HOST)/lib/cargo
-
-CARGO_BIN:=$(CARGO_HOME)/bin
-
 # NOTE: The Rust target triplet does not always match the target triplet used
 # by OpenWrt. You can add exceptions for your device here.
+
+RUST_TARGET_LDFLAGS := $(TARGET_LDFLAGS)
 
 # Turris MOX
 ifneq ($(findstring aarch64,$(CONFIG_ARCH)),)
@@ -14,7 +11,8 @@ else ifneq ($(findstring arm,$(CONFIG_ARCH)),)
   RUST_TARGET := armv7-unknown-linux-musleabihf
 # Turris 1.x
 else ifneq ($(findstring powerpc,$(CONFIG_ARCH)),)
-  RUST_TARGET := powerpc_unknown_linux_muslspe
+  RUST_TARGET := powerpc-unknown-linux-muslspe
+  RUST_TARGET_LDFLAGS += -lssp_nonshared
 else
   RUST_TARGET := $(shell echo $(CONFIG_ARCH)-unknown-linux-$(CONFIG_TARGET_SUFFIX))
 endif
@@ -24,7 +22,7 @@ define CARGO_CONFIG
 ar = "$(TARGET_AR)"
 linker = "$(TARGET_CC)"
 rustflags = [
-  "-C", "link-args=$(TARGET_LDFLAGS)",
+  "-C", "link-args=$(RUST_TARGET_LDFLAGS)",
   "-C", "target-feature=-crt-static",
 ]
 endef

--- a/rust-lang/patches/0001-add-powerpc-unknown-linux-muslspe.patch
+++ b/rust-lang/patches/0001-add-powerpc-unknown-linux-muslspe.patch
@@ -1,0 +1,47 @@
+diff -ruN a/compiler/rustc_target/src/spec/mod.rs b/compiler/rustc_target/src/spec/mod.rs
+--- a/compiler/rustc_target/src/spec/mod.rs	2022-08-08 22:46:10.000000000 +0000
++++ b/compiler/rustc_target/src/spec/mod.rs	2022-08-16 15:03:21.217243041 +0000
+@@ -831,6 +831,7 @@
+     ("powerpc-unknown-linux-gnu", powerpc_unknown_linux_gnu),
+     ("powerpc-unknown-linux-gnuspe", powerpc_unknown_linux_gnuspe),
+     ("powerpc-unknown-linux-musl", powerpc_unknown_linux_musl),
++    ("powerpc-unknown-linux-muslspe", powerpc_unknown_linux_muslspe),
+     ("powerpc64-unknown-linux-gnu", powerpc64_unknown_linux_gnu),
+     ("powerpc64-unknown-linux-musl", powerpc64_unknown_linux_musl),
+     ("powerpc64le-unknown-linux-gnu", powerpc64le_unknown_linux_gnu),
+diff -ruN a/compiler/rustc_target/src/spec/powerpc_unknown_linux_muslspe.rs b/compiler/rustc_target/src/spec/powerpc_unknown_linux_muslspe.rs
+--- a/compiler/rustc_target/src/spec/powerpc_unknown_linux_muslspe.rs	1970-01-01 00:00:00.000000000 +0000
++++ b/compiler/rustc_target/src/spec/powerpc_unknown_linux_muslspe.rs	2022-08-16 15:05:26.697959986 +0000
+@@ -0,0 +1,21 @@
++use crate::abi::Endian;
++use crate::spec::{LinkerFlavor, Target, TargetOptions};
++
++pub fn target() -> Target {
++    let mut base = super::linux_musl_base::opts();
++    base.pre_link_args.entry(LinkerFlavor::Gcc).or_default().push("-mspe".into());
++    base.max_atomic_width = Some(32);
++
++    Target {
++        llvm_target: "powerpc-unknown-linux-muslspe".into(),
++        pointer_width: 32,
++        data_layout: "E-m:e-p:32:32-i64:64-n32".into(),
++        arch: "powerpc".into(),
++        options: TargetOptions {
++            abi: "spe".into(),
++            endian: Endian::Big,
++            mcount: "_mcount".into(),
++            ..base
++        },
++    }
++}
+diff -ruN a/src/doc/rustc/src/platform-support.md b/src/doc/rustc/src/platform-support.md
+--- a/src/doc/rustc/src/platform-support.md	2022-08-08 22:46:10.000000000 +0000
++++ b/src/doc/rustc/src/platform-support.md	2022-08-16 15:04:23.103610246 +0000
+@@ -265,6 +265,7 @@
+ `msp430-none-elf` | * |  | 16-bit MSP430 microcontrollers
+ `powerpc-unknown-linux-gnuspe` | ✓ |  | PowerPC SPE Linux
+ `powerpc-unknown-linux-musl` | ? |  |
++`powerpc-unknown-linux-muslspe` | ? |  | PowerPC SPE Linux
+ `powerpc-unknown-netbsd` | ✓ | ✓ |
+ `powerpc-unknown-openbsd` | ? |  |
+ `powerpc-wrs-vxworks-spe` | ? |  |

--- a/rust-lang/patches/0001-add-powerpc-unknown-linux-muslspe.patch
+++ b/rust-lang/patches/0001-add-powerpc-unknown-linux-muslspe.patch
@@ -1,7 +1,21 @@
-diff -ruN a/compiler/rustc_target/src/spec/mod.rs b/compiler/rustc_target/src/spec/mod.rs
---- a/compiler/rustc_target/src/spec/mod.rs	2022-08-08 22:46:10.000000000 +0000
-+++ b/compiler/rustc_target/src/spec/mod.rs	2022-08-16 15:03:21.217243041 +0000
-@@ -831,6 +831,7 @@
+From fd9502e7c6b358cf7eb04c2824c0aa8a0a9b7ca0 Mon Sep 17 00:00:00 2001
+From: Ondrej Perutka <ondrej.perutka@angelcam.com>
+Date: Mon, 22 Aug 2022 15:12:30 +0200
+Subject: [PATCH] Add powerpc-unknown-linux-muslspe target
+
+Co-authored-by: Josef Schlehofer <pepe.schlehofer@gmail.com>
+---
+ compiler/rustc_target/src/spec/mod.rs         |  1 +
+ .../src/spec/powerpc_unknown_linux_muslspe.rs | 21 +++++++++++++++++++
+ src/doc/rustc/src/platform-support.md         |  1 +
+ 3 files changed, 23 insertions(+)
+ create mode 100644 compiler/rustc_target/src/spec/powerpc_unknown_linux_muslspe.rs
+
+diff --git a/compiler/rustc_target/src/spec/mod.rs b/compiler/rustc_target/src/spec/mod.rs
+index da0589cdd20..46bfd6c4ba2 100644
+--- a/compiler/rustc_target/src/spec/mod.rs
++++ b/compiler/rustc_target/src/spec/mod.rs
+@@ -831,6 +831,7 @@ fn $module() {
      ("powerpc-unknown-linux-gnu", powerpc_unknown_linux_gnu),
      ("powerpc-unknown-linux-gnuspe", powerpc_unknown_linux_gnuspe),
      ("powerpc-unknown-linux-musl", powerpc_unknown_linux_musl),
@@ -9,9 +23,11 @@ diff -ruN a/compiler/rustc_target/src/spec/mod.rs b/compiler/rustc_target/src/sp
      ("powerpc64-unknown-linux-gnu", powerpc64_unknown_linux_gnu),
      ("powerpc64-unknown-linux-musl", powerpc64_unknown_linux_musl),
      ("powerpc64le-unknown-linux-gnu", powerpc64le_unknown_linux_gnu),
-diff -ruN a/compiler/rustc_target/src/spec/powerpc_unknown_linux_muslspe.rs b/compiler/rustc_target/src/spec/powerpc_unknown_linux_muslspe.rs
---- a/compiler/rustc_target/src/spec/powerpc_unknown_linux_muslspe.rs	1970-01-01 00:00:00.000000000 +0000
-+++ b/compiler/rustc_target/src/spec/powerpc_unknown_linux_muslspe.rs	2022-08-16 15:05:26.697959986 +0000
+diff --git a/compiler/rustc_target/src/spec/powerpc_unknown_linux_muslspe.rs b/compiler/rustc_target/src/spec/powerpc_unknown_linux_muslspe.rs
+new file mode 100644
+index 00000000000..44557a3bd70
+--- /dev/null
++++ b/compiler/rustc_target/src/spec/powerpc_unknown_linux_muslspe.rs
 @@ -0,0 +1,21 @@
 +use crate::abi::Endian;
 +use crate::spec::{LinkerFlavor, Target, TargetOptions};
@@ -34,10 +50,11 @@ diff -ruN a/compiler/rustc_target/src/spec/powerpc_unknown_linux_muslspe.rs b/co
 +        },
 +    }
 +}
-diff -ruN a/src/doc/rustc/src/platform-support.md b/src/doc/rustc/src/platform-support.md
---- a/src/doc/rustc/src/platform-support.md	2022-08-08 22:46:10.000000000 +0000
-+++ b/src/doc/rustc/src/platform-support.md	2022-08-16 15:04:23.103610246 +0000
-@@ -265,6 +265,7 @@
+diff --git a/src/doc/rustc/src/platform-support.md b/src/doc/rustc/src/platform-support.md
+index eb985803266..281080971c1 100644
+--- a/src/doc/rustc/src/platform-support.md
++++ b/src/doc/rustc/src/platform-support.md
+@@ -265,6 +265,7 @@ target | std | host | notes
  `msp430-none-elf` | * |  | 16-bit MSP430 microcontrollers
  `powerpc-unknown-linux-gnuspe` | ✓ |  | PowerPC SPE Linux
  `powerpc-unknown-linux-musl` | ? |  |
@@ -45,3 +62,6 @@ diff -ruN a/src/doc/rustc/src/platform-support.md b/src/doc/rustc/src/platform-s
  `powerpc-unknown-netbsd` | ✓ | ✓ |
  `powerpc-unknown-openbsd` | ? |  |
  `powerpc-wrs-vxworks-spe` | ? |  |
+-- 
+2.37.2
+


### PR DESCRIPTION
Fixes #3 and #7.

Please note that the standalone Rust binary (as proposed at #3) isn't being used here for bootstrapping. Instead, we let the Rust build scripts download their own bootstrapping binary. This shouldn't sacrifice safety/reproducibility of the build as the Rust build machinery does the necessary checks (see https://github.com/rust-lang/rust/blob/master/src/stage0.json).